### PR TITLE
Add non 200 support

### DIFF
--- a/lib/rims/controller.rb
+++ b/lib/rims/controller.rb
@@ -1,3 +1,4 @@
+require 'rack'
 require 'rims/endpoint'
 require 'rims/language_extensions/module'
 require 'rims/language_extensions/class'

--- a/lib/rims/controller.rb
+++ b/lib/rims/controller.rb
@@ -36,16 +36,22 @@ module Rims
     end
 
     attr_reader :request
-    attr_func :status
+    attr_func :status, :body
 
     def initialize(env)
       @request = Rack::Request.new(env)
       status 200
+      body nil
     end
 
     def call
-      body = instance_eval(&self.class._action)
+      body instance_eval(&self.class._action)
       [status, {}, [body]]
+    end
+
+    def render(body, opts = {})
+      status(opts[:status] || 200)
+      return body
     end
   end
 end

--- a/rims.gemspec
+++ b/rims.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "journey", "~> 1.0"
+  spec.add_runtime_dependency "rack", "~> 1.6.0"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -12,6 +12,14 @@ class ControllerTest < MiniTest::Test
     end
   end
 
+  class FourOhFourController < Rims::Controller
+    description "404s"
+    route :get, "/nonexistent"
+    action do
+      render "Oh no!", status: 404
+    end
+  end
+
   def test_controller_has_description
     assert_equal "Fake Controller", FakeController.description
   end
@@ -24,5 +32,12 @@ class ControllerTest < MiniTest::Test
 
   def test_controllers_are_registered
     assert_includes Rims::Controller.registry, FakeController
+  end
+
+  def test_controllers_can_render_statuses
+    f = FourOhFourController.new(MiniTest::Mock.new)
+    result = f.call
+    assert_equal 404, result[0]
+    assert_equal ["Oh no!"], result[2]
   end
 end

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -18,7 +18,7 @@ class ControllerTest < MiniTest::Test
 
   def test_route_adds_an_endpoint
     endpoint = FakeController.endpoints.first
-    assert_equal :post, endpoint.verb
+    assert_equal "POST", endpoint.verb
     assert_equal "/fake", endpoint.path
   end
 


### PR DESCRIPTION
A little Saturday morning hacking :coffee:
This adds a `render` command that takes a body and an options hash. Much more to be done on the way to a full tilt/view layer implementation, but it's a step :walking: 
